### PR TITLE
patch for p<1 to mask 0 dist entries

### DIFF
--- a/include/p_norm_gradient.cuh
+++ b/include/p_norm_gradient.cuh
@@ -382,6 +382,7 @@ kernel_cute_p_norm_kernel_gradient(
                         diff = diff;
                     } else {
                         diff = _abs(diff);
+                        diff = diff < 1e-8f ? 1e-8f : diff;
                         diff = _pow(diff, p_power_grad);
                         diff = diff * sign;
                     }


### PR DESCRIPTION
Clamp distances to eps=1e-8 to permit p<1 for cdist_grad. 